### PR TITLE
Adding another sample app to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Here is [sample app](https://github.com/yury/ibsample)
 
 **Note** : this app is build for iOS 6.0
 
+# Another Sample app
+
+Here is [another sample app](https://github.com/hqmq/whereami)
+
+You can play around with it in the same way as the Sample app above. This sample uses a single xib file rather than a storyboard.
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
I really liked using your gem and I want to use it as I work my way through the Big Nerd Ranch iOS book.  It took me a couple of tries to figure out exactly how to use a single xib file with a given view controller so I figured I would just add a link to my sample app.

Is this something your interested in adding? Maybe I could add it to the wiki for the project rather than the README? Or write up a step-by-step guide for a really simple app? I just want to add some documentation to the project.
