### PR TITLE
Update xcodeproj dependency to 0.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     ib (0.4.7)
       thor (~> 0.15.4)
       tilt (~> 1.4.1)
-      xcodeproj (~> 0.16.0)
+      xcodeproj (~> 0.17)
 
 GEM
   remote: https://rubygems.org/
@@ -58,7 +58,7 @@ GEM
     slop (3.5.0)
     thor (0.15.4)
     tilt (1.4.1)
-    xcodeproj (0.16.1)
+    xcodeproj (0.17.0)
       activesupport (~> 3.0)
       colored (~> 1.2)
 

--- a/ib.gemspec
+++ b/ib.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = IB::VERSION
 
-  gem.add_dependency 'xcodeproj', '~> 0.16.0'
+  gem.add_dependency 'xcodeproj', '~> 0.17'
   gem.add_dependency 'thor',      '~> 0.15.4'
   gem.add_dependency 'tilt',      '~> 1.4.1'
 


### PR DESCRIPTION
The newest cocoapods gem (0.33.1) requires xcodeproj 0.17.0, but this project was locked to 0.16.x

Not sure if there was a reason ib is being locked to this minor version, but this change will allow any updates xcodeproj gem as long as it's still 0.x

(I couldn't get the specs to run properly even before changing anything, but after this change, ib still works fine for me on my current app).
