### PR TITLE
Add support for assets catalogs (.xcassets) when building resources

### DIFF
--- a/lib/ib/project.rb
+++ b/lib/ib/project.rb
@@ -88,7 +88,13 @@ class IB::Project
   end
 
   def add_resources
-    Dir.glob("#{resources.path}/**/*.{#{RESOURCE_EXTENSIONS.join(",")}}") do |file|
+    # First add reference to any asset catalogs.
+    Dir.glob("#{resources.path}/**/*.xcassets") do |file|
+      resources.new_reference(file)
+    end
+    # Add all other resources, ignoring files in existing asset catalogs
+    Dir["#{resources.path}/**/*.{#{RESOURCE_EXTENSIONS.join(",")}}"]
+      .reject {|f| f[%r{.*\.xcassets/.*}] }.each do |file|
       resources.new_reference(file)
     end
   end


### PR DESCRIPTION
This commit solves [open issue #56](https://github.com/rubymotion/ib/issues/56).  Any existing Asset Catalogs (with the .xcassets extension) are added to the project's resources.  Also, any resources (PNGs, JPEGs, etc) within an Asset Catalog is ignored.
