### PR TITLE
Create additional frameworks

### DIFF
--- a/lib/ib/project.rb
+++ b/lib/ib/project.rb
@@ -116,8 +116,7 @@ class IB::Project
   end
 
   def extra_frameworks
-    extra_frameworks = Motion::Project::App.config.vendor_projects
-    extra_frameworks = extra_frameworks.select { |vp| vp.opts[:ib] }
+    Motion::Project::App.config.vendor_projects.select { |vp| vp.opts[:ib] }
   end
 
   def add_extra_framework(framework)


### PR DESCRIPTION
I wanted to be able to leverage the power of IB_DESIGNABLE/IBInspectable.  This commit allows you to pass over custom frameworks during project generation, which is incredibly handy.

Example in your project Rakefile:
`app.vendor_project('frameworks/DesignableKit', :static, { ib: true })`

passing `ib: true` in the opts for vendor_project will create a custom framework for you.

Try this simple gist, and put the files in `frameworks/DesignableKit`
https://gist.github.com/malkomalko/09688f2880bd7a879a17

Rejoice! http://quick.as/rm6kixgg
