### PR TITLE
Typo fix, `UIStoryBoard` => `UIStoryboard`

### DIFF
--- a/lib/ib/oc_interface.rb
+++ b/lib/ib/oc_interface.rb
@@ -15,7 +15,7 @@ class IB::OCInterface
     def to_declare
       if arg
         if arg =~ /story_?board/i
-          "#{variable}:(UIStoryBoard *) #{arg}"
+          "#{variable}:(UIStoryboard *) #{arg}"
         else
           "#{variable}:(#{return_type ? "#{return_type}*" : 'id'}) #{arg}"
         end


### PR DESCRIPTION
Fixes https://github.com/rubymotion/ib/issues/82#issuecomment-136806357